### PR TITLE
Stabilise Fragmented Log API

### DIFF
--- a/szd/core/src/szd.c
+++ b/szd/core/src/szd.c
@@ -720,7 +720,7 @@ int szd_reset(QPair *qpair, uint64_t slba) {
   RETURN_ERR_ON_NULL(qpair);
   // Otherwise we have an out of range.
   DeviceInfo info = qpair->man->info;
-  if (slba < info.min_lba || slba > info.lba_cap) {
+  if (slba < info.min_lba || slba >= info.lba_cap) {
     return SZD_SC_SPDK_ERROR_READ;
   }
   Completion completion = Completion_default;
@@ -735,6 +735,7 @@ int szd_reset(QPair *qpair, uint64_t slba) {
   // Busy wait
   POLL_QPAIR(qpair->qpair, completion.done);
   if (completion.err != 0) {
+    printf("Reset err %x \n", completion.err);
     return SZD_SC_SPDK_ERROR_RESET;
   }
   return rc;

--- a/szd/cpp/src/szd_channel.cpp
+++ b/szd/cpp/src/szd_channel.cpp
@@ -468,6 +468,7 @@ SZDStatus SZDChannel::Sync() {
 SZDStatus SZDChannel::ResetZone(uint64_t slba) {
   slba = TranslateLbaToPba(slba);
   if (slba < min_lba_ || slba > max_lba_) {
+    printf("Reset out of range %lu  - %lu -  %lu\n", min_lba_, slba, max_lba_);
     return SZDStatus::InvalidArguments;
   }
   SZDStatus s = FromStatus(szd_reset(qpair_, slba));


### PR DESCRIPTION
The fragmented log API was temporarily hardcoded for TropoDB.
The following change will break the API, requiring all software dependent on SZD to update.
The cost will be worth it.