### PR TITLE
Repair Doxygen generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,11 +240,12 @@ if(DOXYGEN)
             
         # request to configure the file
         configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
-        add_custom_target( docs
+        add_custom_target(docs
             COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
             WORKING_DIRECTORY ${DOCS_DIR}
             COMMENT "Generating API documentation with Doxygen"
             VERBATIM )
+        message("Doxygen found")
     else(DOXYGEN_FOUND)
         message("No documentation can be generated, DOXYGEN is not found")
     endif(DOXYGEN_FOUND)

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,4 +1,6 @@
 OUTPUT_DIRECTORY       = @DOCS_DIR@/generated/
-INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/include/ @DOCS_DIR@
+INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/szd @DOCS_DIR@
 GENERATE_HTML          = YES
-GENERATE_MAN           = YES
+GENERATE_MAN           = NO
+GENERATE_LATEX         = NO
+RECURSIVE              = YES


### PR DESCRIPTION
## What is the intent of this PR?
Repair Doxygen functionality. 

## Checklist
- [ :no_entry: ] all tests complete. Make sure you have `-DTESTING=1` and `make test` completes.
- [ :heavy_check_mark: ] code is formatted. This includes ALL code. For now, this can be done with:
```bash
mkdir -p build && cd build
cmake -DTESTING=1 -DSZD_TOOLS="szdcli; reset_perf" ..
make format
```
