### PR TITLE
Cleanup error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SimpleZNSDevice (SZD)
 SimpleZNSDevice is a simpler wrapper around SPDK that allows developing for ZNS devices without (much) effort.
-It only uses a subset of what is currently possible with SPDK, but it greatly simplifies the logic that would otherwise be necessary and comes with some utility functions. It is mainly developed to be used in an alteration of RocksDB, [ZNSLSM](https://github.com/Krien/znslsm). However, since the logic can also be used for other ZNS projects, it got its own repository. The project contains an interface that can be used with both C and C++, known as `SZD`, see [./incude/core](./include/core), some simple debugging and utility tools that make use of the interface, see [./tools](tools) and a small C++-only library of extra ZNS-targeted functions and data structures, known as `SZD_extended`, in [./include/cpp](./include/cpp).
+It only uses a subset of what is currently possible with SPDK, but it greatly simplifies the logic that would otherwise be necessary and comes with some utility functions. It is mainly developed to be used in an alteration of RocksDB, [TropoDB](https://github.com/Krien/TropoDB). However, since the logic can also be used for other ZNS projects, it got its own repository. The project contains an interface that can be used with both C and C++, known as `SZD`, see [./incude/core](./include/core), some simple debugging and utility tools that make use of the interface, see [./tools](tools) and a small C++-only library of extra ZNS-targeted functions and data structures, known as `SZD_extended`, in [./include/cpp](./include/cpp).
 
 # DISCLAIMER
 This code is in early stages of development and prone to change. Use at own risk, for more "risk-involved" information read the rest of this section.
@@ -14,7 +14,7 @@ It can at the moment be used as a:
 # How to use SZD_extended
 SZD_extended wrapps the SZD library in a more C++ like interface. This should make the development smoother and feel less out of place when used in C++. It also comes with a bigger set of functionalities. It has threadsafe QPair abstractions known as `SZDChannels` and various log structures (fitting for ZNS) such as `SZDOnceLog`, `SZDCircularLog` and `SZDFragmentedLog`. It can at the moment be used as a:
 
-* Static library called `szd_extended`. This also comes with C++ functionalities on top of the interface, so do not use with C projects. For examples on how to use this lib, see the tests or [ZNSLSM](https://github.com/Krien/znslsm).
+* Static library called `szd_extended`. This also comes with C++ functionalities on top of the interface, so do not use with C projects. For examples on how to use this lib, see the tests or [TropoDB](https://github.com/Krien/TropoDB).
 
 # How to build
 There are multiple ways to built this project.

--- a/szd/cpp/src/datastructures/szd_fragmented_log.cpp
+++ b/szd/cpp/src/datastructures/szd_fragmented_log.cpp
@@ -361,7 +361,6 @@ SZDFragmentedLog::Reset(std::vector<std::pair<uint64_t, uint64_t>> &regions,
   for (auto region : regions) {
     uint64_t begin = region.first * zone_cap_;
     uint64_t end = begin + region.second * zone_cap_;
-    printf("BEGIN %lu STEP %lu END %lu \n", begin, zone_cap_, end);
     for (uint64_t slba = begin; slba < end; slba += zone_cap_) {
       s = write_channel_[writer]->ResetZone(slba);
       if (s != SZDStatus::Success) {


### PR DESCRIPTION
## What is the intent of this PR?
The intent of this PR is to clean up some of SZD's core.
We have:
- Removed most NULL checks in production. No branch spraying.
- Added some "likely/unlikely" hints to error checks
- Removed spurious printfs
- Moved error printfs in SZD to SPDK Error logs
- Updated the README to use TropoDB, not ZNSLSM

## Checklist
- [ :no_entry: ] all tests complete. Make sure you have `-DTESTING=1` and `make test` completes.
- [:heavy_check_mark: ] code is formatted. This includes ALL code. For now, this can be done with:
```bash
mkdir -p build && cd build
cmake -DTESTING=1 -DSZD_TOOLS="szdcli; reset_perf" ..
make format
```
