### PR TITLE
Remove printfs and many checks

### DIFF
--- a/szd/core/include/szd/szd.h
+++ b/szd/core/include/szd/szd.h
@@ -316,6 +316,19 @@ void szd_print_zns_status(int status);
  */
 long int szd_spdk_strtol(const char *nptr, int base);
 
+#ifdef NDBEUG
+#define SZD_LOG_ERROR(...)  do {} while(0)
+#else
+#define SZD_LOG_ERROR(...)                                                     \
+  __szd_error_log(__FILE__, __LINE__, __func__, __VA_ARGS__)
+#endif
+
+// Taken from spdk/likely (no leakage)
+#define szd_unlikely(cond)	__builtin_expect((cond), 0)
+
+void __szd_error_log(const char *file, const int line, const char *func,
+                     const char *format, ...);
+
 bool __szd_probe_probe_cb(void *cb_ctx, const t_spdk_nvme_transport_id *trid,
                           t_spdk_nvme_ctrlr_opts *opts);
 

--- a/szd/core/include/szd/szd.h
+++ b/szd/core/include/szd/szd.h
@@ -1,3 +1,36 @@
+/*-
+ *   BSD LICENSE
+ *
+ *   Copyright (c) Intel Corporation. All rights reserved.
+ *   Copyright (c) 2019 Mellanox Technologies LTD. All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 /** \file
  * Main SZD interface.
  */
@@ -317,14 +350,17 @@ void szd_print_zns_status(int status);
 long int szd_spdk_strtol(const char *nptr, int base);
 
 #ifdef NDBEUG
-#define SZD_LOG_ERROR(...)  do {} while(0)
+#define SZD_LOG_ERROR(...)                                                     \
+  do {                                                                         \
+  } while (0)
 #else
 #define SZD_LOG_ERROR(...)                                                     \
   __szd_error_log(__FILE__, __LINE__, __func__, __VA_ARGS__)
 #endif
 
-// Taken from spdk/likely (no leakage)
-#define szd_unlikely(cond)	__builtin_expect((cond), 0)
+// Taken directly (renamed) from spdk/likely (no leakage)
+#define szd_unlikely(cond) __builtin_expect((cond), 0)
+#define szd_likely(cond) __builtin_expect(!!(cond), 1)
 
 void __szd_error_log(const char *file, const int line, const char *func,
                      const char *format, ...);

--- a/szd/core/src/szd.c
+++ b/szd/core/src/szd.c
@@ -924,6 +924,17 @@ long int szd_spdk_strtol(const char *nptr, int base) {
   return spdk_strtol(nptr, base);
 }
 
+void __szd_error_log(const char *file, const int line, const char *func,
+                     const char *format, ...) {
+  // TODO: cleanup
+  // For now resort to SPDK's internal error printing (not-maintainable)
+  va_list ap;
+
+  va_start(ap, format);
+  spdk_vlog(SPDK_LOG_ERROR, file, line, func, format, ap);
+  va_end(ap);
+}
+
 #ifdef __cplusplus
 }
 } // namespace SimpleZNSDeviceNamespace

--- a/szd/cpp/src/datastructures/szd_buffer.cpp
+++ b/szd/cpp/src/datastructures/szd_buffer.cpp
@@ -27,7 +27,7 @@ SZDBuffer::~SZDBuffer() {
 }
 
 SZDStatus SZDBuffer::GetBuffer(void **buffer) const {
-  if (backed_memory_ == nullptr) {
+  if (szd_unlikely(backed_memory_ == nullptr)) {
     SZD_LOG_ERROR("SZD: Buffer: GetBuffer: NULL\n");
     return SZDStatus::IOError;
   }
@@ -36,7 +36,7 @@ SZDStatus SZDBuffer::GetBuffer(void **buffer) const {
 }
 SZDStatus SZDBuffer::AppendToBuffer(void *data, size_t *write_head,
                                     size_t size) {
-  if (*write_head + size > backed_memory_size_) {
+  if (szd_unlikely(*write_head + size > backed_memory_size_)) {
     SZD_LOG_ERROR("SZD: Buffer: AppendToBuffer: OOB\n");
     return SZDStatus::InvalidArguments;
   }
@@ -46,7 +46,7 @@ SZDStatus SZDBuffer::AppendToBuffer(void *data, size_t *write_head,
 }
 
 SZDStatus SZDBuffer::WriteToBuffer(void *data, size_t addr, size_t size) {
-  if (addr + size > backed_memory_size_) {
+  if (szd_unlikely(addr + size > backed_memory_size_)) {
     SZD_LOG_ERROR("SZD: Buffer: WriteToBuffer: OOB\n");
     return SZDStatus::InvalidArguments;
   }
@@ -56,7 +56,7 @@ SZDStatus SZDBuffer::WriteToBuffer(void *data, size_t addr, size_t size) {
 
 SZDStatus SZDBuffer::ReadFromBuffer(void *data, size_t addr,
                                     size_t size) const {
-  if (addr + size > backed_memory_size_) {
+  if (szd_unlikely(addr + size > backed_memory_size_)) {
     SZD_LOG_ERROR("SZD: Buffer: ReadFromBuffer: OOB\n");
     return SZDStatus::InvalidArguments;
   }
@@ -82,7 +82,7 @@ SZDStatus SZDBuffer::ReallocBuffer(uint64_t size) {
     }
   }
   backed_memory_ = szd_calloc(lba_size_, alligned_size, sizeof(char));
-  if (backed_memory_ == nullptr) {
+  if (szd_unlikely(backed_memory_ == nullptr)) {
     backed_memory_size_ = 0;
     SZD_LOG_ERROR("SZD: Buffer: ReallocBuffer: Failed allocating memory\n");
     return SZDStatus::IOError;

--- a/szd/cpp/src/datastructures/szd_buffer.cpp
+++ b/szd/cpp/src/datastructures/szd_buffer.cpp
@@ -28,6 +28,7 @@ SZDBuffer::~SZDBuffer() {
 
 SZDStatus SZDBuffer::GetBuffer(void **buffer) const {
   if (backed_memory_ == nullptr) {
+    SZD_LOG_ERROR("SZD: Buffer: GetBuffer: NULL\n");
     return SZDStatus::IOError;
   }
   *buffer = backed_memory_;
@@ -36,6 +37,7 @@ SZDStatus SZDBuffer::GetBuffer(void **buffer) const {
 SZDStatus SZDBuffer::AppendToBuffer(void *data, size_t *write_head,
                                     size_t size) {
   if (*write_head + size > backed_memory_size_) {
+    SZD_LOG_ERROR("SZD: Buffer: AppendToBuffer: OOB\n");
     return SZDStatus::InvalidArguments;
   }
   memmove((char *)backed_memory_ + *write_head, data, size);
@@ -45,6 +47,7 @@ SZDStatus SZDBuffer::AppendToBuffer(void *data, size_t *write_head,
 
 SZDStatus SZDBuffer::WriteToBuffer(void *data, size_t addr, size_t size) {
   if (addr + size > backed_memory_size_) {
+    SZD_LOG_ERROR("SZD: Buffer: WriteToBuffer: OOB\n");
     return SZDStatus::InvalidArguments;
   }
   memmove((char *)backed_memory_ + addr, data, size);
@@ -54,6 +57,7 @@ SZDStatus SZDBuffer::WriteToBuffer(void *data, size_t addr, size_t size) {
 SZDStatus SZDBuffer::ReadFromBuffer(void *data, size_t addr,
                                     size_t size) const {
   if (addr + size > backed_memory_size_) {
+    SZD_LOG_ERROR("SZD: Buffer: ReadFromBuffer: OOB\n");
     return SZDStatus::InvalidArguments;
   }
   memmove(data, (char *)backed_memory_ + addr, size);
@@ -73,12 +77,14 @@ SZDStatus SZDBuffer::ReallocBuffer(uint64_t size) {
   if (backed_memory_size_ > 0) {
     memcpy(tmp, backed_memory_, backed_memory_size_);
     if ((s = FreeBuffer()) != SZDStatus::Success) {
+      SZD_LOG_ERROR("SZD: Buffer: ReallocBuffer: Failed free\n");
       return s;
     }
   }
   backed_memory_ = szd_calloc(lba_size_, alligned_size, sizeof(char));
   if (backed_memory_ == nullptr) {
     backed_memory_size_ = 0;
+    SZD_LOG_ERROR("SZD: Buffer: ReallocBuffer: Failed allocating memory\n");
     return SZDStatus::IOError;
   }
   if (backed_memory_size_ > 0) {

--- a/szd/cpp/src/datastructures/szd_freezone_list.cpp
+++ b/szd/cpp/src/datastructures/szd_freezone_list.cpp
@@ -50,7 +50,7 @@ SZDFreeList *lastZoneRegion(SZDFreeList *target) {
 }
 
 void FreeZones(SZDFreeList *target, SZDFreeList **orig) {
-  if (!target->used_) {
+  if (szd_unlikely(!target->used_)) {
     // This, this is highly illegal!
     SZD_LOG_ERROR("SZD: Freezone: double free\n");
     return;
@@ -89,7 +89,7 @@ void FreeZones(SZDFreeList *target, SZDFreeList **orig) {
 }
 
 void AllocZonesFromRegion(SZDFreeList *target, uint64_t zones) {
-  if (target->used_ || target->zones_ < zones) {
+  if (szd_unlikely(target->used_ || target->zones_ < zones)) {
     // Should not happen obviously
     SZD_LOG_ERROR("SZD: Freezone: double alloc\n");
     return;
@@ -215,14 +215,14 @@ char *EncodeFreelist(SZDFreeList *target, uint64_t *size) {
 
 SZDStatus DecodeFreelist(const char *buffer, uint64_t buffer_size,
                          SZDFreeList **target, uint32_t *zones_free) {
-  if (buffer_size < sizeof(uint64_t)) {
+  if (szd_unlikely(buffer_size < sizeof(uint64_t))) {
     SZD_LOG_ERROR("SZD: Freelist: DecodeFreeList: Invalid buffersize\n");
     return SZDStatus::InvalidArguments;
   }
   // Size of original encoded string.
   uint64_t true_size;
   true_size = Decode64(buffer);
-  if (true_size > buffer_size) {
+  if (szd_unlikely(true_size > buffer_size)) {
     SZD_LOG_ERROR("SZD: Freelist: DecodeFreeList: Size mismatch\n");
     return SZDStatus::InvalidArguments;
   }

--- a/szd/cpp/src/datastructures/szd_freezone_list.cpp
+++ b/szd/cpp/src/datastructures/szd_freezone_list.cpp
@@ -52,6 +52,7 @@ SZDFreeList *lastZoneRegion(SZDFreeList *target) {
 void FreeZones(SZDFreeList *target, SZDFreeList **orig) {
   if (!target->used_) {
     // This, this is highly illegal!
+    SZD_LOG_ERROR("SZD: Freezone: double free\n");
     return;
   }
   // Checkpoint to ensure that target can be deleted
@@ -90,6 +91,7 @@ void FreeZones(SZDFreeList *target, SZDFreeList **orig) {
 void AllocZonesFromRegion(SZDFreeList *target, uint64_t zones) {
   if (target->used_ || target->zones_ < zones) {
     // Should not happen obviously
+    SZD_LOG_ERROR("SZD: Freezone: double alloc\n");
     return;
   }
   // Split
@@ -148,6 +150,7 @@ SZDStatus AllocZones(std::vector<std::pair<uint64_t, u_int64_t>> &zone_regions,
   if ((*from) == nullptr) {
     *from = start; // prevents memory leaks and nullptrs
   }
+  SZD_LOG_ERROR("SZD: Freezone: Could not allocate\n");
   return SZDStatus::InvalidArguments;
 }
 
@@ -161,6 +164,7 @@ SZDStatus FindRegion(const uint64_t ident, SZDFreeList *from,
     }
     first = first->next_;
   }
+  SZD_LOG_ERROR("SZD: Freezone: FindRegion: Invalid args\n");
   return SZDStatus::InvalidArguments;
 }
 
@@ -212,12 +216,14 @@ char *EncodeFreelist(SZDFreeList *target, uint64_t *size) {
 SZDStatus DecodeFreelist(const char *buffer, uint64_t buffer_size,
                          SZDFreeList **target, uint32_t *zones_free) {
   if (buffer_size < sizeof(uint64_t)) {
+    SZD_LOG_ERROR("SZD: Freelist: DecodeFreeList: Invalid buffersize\n");
     return SZDStatus::InvalidArguments;
   }
   // Size of original encoded string.
   uint64_t true_size;
   true_size = Decode64(buffer);
   if (true_size > buffer_size) {
+    SZD_LOG_ERROR("SZD: Freelist: DecodeFreeList: Size mismatch\n");
     return SZDStatus::InvalidArguments;
   }
   buffer_size = true_size;

--- a/szd/cpp/src/datastructures/szd_once_log.cpp
+++ b/szd/cpp/src/datastructures/szd_once_log.cpp
@@ -60,6 +60,7 @@ SZDStatus SZDOnceLog::Append(const char *data, const size_t size,
     if (lbas != nullptr) {
       *lbas = 0;
     }
+    SZD_LOG_ERROR("SZD: Once log: Append: No space left\n");
     return SZDStatus::IOError;
   }
   uint64_t write_head_old = write_head_;
@@ -85,6 +86,7 @@ SZDStatus SZDOnceLog::Append(const SZDBuffer &buffer, size_t addr, size_t size,
     if (lbas != nullptr) {
       *lbas = 0;
     }
+    SZD_LOG_ERROR("SZD: Once log: Append: No space left\n");
     return SZDStatus::IOError;
   }
   uint64_t write_head_old = write_head_;
@@ -105,6 +107,7 @@ SZDStatus SZDOnceLog::Append(const SZDBuffer &buffer, uint64_t *lbas) {
     if (lbas != nullptr) {
       *lbas = 0;
     }
+    SZD_LOG_ERROR("SZD: Once log: Append: No space left\n");
     return SZDStatus::IOError;
   }
   uint64_t write_head_old = write_head_;
@@ -124,6 +127,7 @@ SZDStatus SZDOnceLog::AsyncAppend(const char *data, const size_t size,
     if (lbas != nullptr) {
       *lbas = 0;
     }
+    SZD_LOG_ERROR("SZD: Once log: Async Append: No space left\n");
     return SZDStatus::IOError;
   }
   uint64_t zone_end = (write_head_ / zone_cap_) * zone_cap_ + zone_cap_;
@@ -133,14 +137,9 @@ SZDStatus SZDOnceLog::AsyncAppend(const char *data, const size_t size,
   bool can_do_async = blocks_needed <= zasl_ / lba_size_ &&
                       write_head_ + blocks_needed < zone_end;
   // We need to sync all previous writes first, then do a direct append
-  // printf("checking if sync mode %lu %lu %lu %lu\n", blocks_needed,
-  //        zasl_ / lba_size_, write_head_, zone_end);
-
   // Try to claim a channel
   uint32_t claimed_nr = 0;
   if (!can_do_async) {
-    // printf("Going sync mode %lu %lu %lu %lu %lu\n", blocks_needed,
-    //        zasl_ / lba_size_, write_head_, zone_end, max_zone_head_);
     s = Sync();
     claimed_nr = 0;
     s = write_channel_[0]->DirectAppend(&write_head_, (void *)data, size,
@@ -154,7 +153,6 @@ SZDStatus SZDOnceLog::AsyncAppend(const char *data, const size_t size,
       }
       waiting++;
     }
-    // printf("claimed nr %u %lu \n", claimed_nr, waiting);
     s = write_channel_[0]->AsyncAppend(&write_head_, (void *)data, size,
                                        claimed_nr);
   }
@@ -162,10 +160,8 @@ SZDStatus SZDOnceLog::AsyncAppend(const char *data, const size_t size,
     *lbas = blocks_needed;
   }
   space_left_ -= blocks_needed * lba_size_;
-  // printf("Space left %lu - %lu - %lu\n", write_head_, max_zone_head_,
-  //        space_left_);
   return s;
-} // namespace SIMPLE_ZNS_DEVICE_NAMESPACE
+}
 
 SZDStatus SZDOnceLog::Sync() {
   SZDStatus s = SZDStatus::Success;
@@ -189,6 +185,7 @@ bool SZDOnceLog::IsValidAddress(uint64_t lba, uint64_t lbas) {
 SZDStatus SZDOnceLog::Read(uint64_t lba, char *data, uint64_t size,
                            bool alligned, uint8_t /*reader*/) {
   if (!IsValidAddress(lba, read_channel_->allign_size(size) / lba_size_)) {
+    SZD_LOG_ERROR("SZD: Once log: Read: Invalid args\n");
     return SZDStatus::InvalidArguments;
   }
   return read_channel_->DirectRead(lba, data, size, alligned);
@@ -197,6 +194,7 @@ SZDStatus SZDOnceLog::Read(uint64_t lba, char *data, uint64_t size,
 SZDStatus SZDOnceLog::Read(uint64_t lba, SZDBuffer *buffer, uint64_t size,
                            bool alligned, uint8_t /*reader*/) {
   if (!IsValidAddress(lba, read_channel_->allign_size(size) / lba_size_)) {
+    SZD_LOG_ERROR("SZD: Once log: Read: Invalid args\n");
     return SZDStatus::InvalidArguments;
   }
   return read_channel_->ReadIntoBuffer(lba, buffer, 0, size, alligned);
@@ -205,6 +203,7 @@ SZDStatus SZDOnceLog::Read(uint64_t lba, SZDBuffer *buffer, uint64_t size,
 SZDStatus SZDOnceLog::Read(uint64_t lba, SZDBuffer *buffer, size_t addr,
                            size_t size, bool alligned, uint8_t /*reader*/) {
   if (!IsValidAddress(lba, read_channel_->allign_size(size) / lba_size_)) {
+    SZD_LOG_ERROR("SZD: Once log: Read: Invalid args\n");
     return SZDStatus::InvalidArguments;
   }
   return read_channel_->ReadIntoBuffer(lba, buffer, addr, size, alligned);
@@ -213,12 +212,14 @@ SZDStatus SZDOnceLog::Read(uint64_t lba, SZDBuffer *buffer, size_t addr,
 SZDStatus SZDOnceLog::ReadAll(std::string &out) {
   size_t size_needed = (GetWriteHead() - GetWriteTail()) * lba_size_;
   if (size_needed == 0) {
+    SZD_LOG_ERROR("SZD: Once log: ReadAll: Invalid args\n");
     return SZDStatus::Success;
   }
   char *dat = new char[size_needed + 1];
   SZDStatus s =
       read_channel_->DirectRead(GetWriteTail(), dat, size_needed, true);
   if (s != SZDStatus::Success) {
+    SZD_LOG_ERROR("SZD: Once log: ReadAll: Failed\n");
     return s;
   }
   out.append(dat, size_needed);
@@ -232,6 +233,7 @@ SZDStatus SZDOnceLog::ResetAll() {
        slba < max_zone_head_ && slba < write_head_; slba += zone_cap_) {
     s = read_channel_->ResetZone(slba);
     if (s != SZDStatus::Success) {
+      SZD_LOG_ERROR("SZD: Once log: ResetZone\n");
       return s;
     }
   }
@@ -249,6 +251,7 @@ SZDStatus SZDOnceLog::RecoverPointers() {
        slba += zone_cap_) {
     s = read_channel_->ZoneHead(slba, &zone_head);
     if (s != SZDStatus::Success) {
+      SZD_LOG_ERROR("SZD: Once log: Recover pointers\n");
       return s;
     }
     // head is at last zone that is not empty

--- a/szd/cpp/src/szd_channel.cpp
+++ b/szd/cpp/src/szd_channel.cpp
@@ -76,7 +76,6 @@ uint64_t SZDChannel::TranslateLbaToPba(uint64_t lba) {
   // determine lba by going to actual zone offset and readding offset.
   uint64_t slba = (lba / zone_cap_) * zone_size_;
   uint64_t slba_offset = lba % zone_cap_;
-  // printf("translate lba to pba %lu %lu %lu\n", lba, slba, slba_offset);
   return slba + slba_offset;
 }
 
@@ -84,7 +83,6 @@ uint64_t SZDChannel::TranslatePbaToLba(uint64_t lba) {
   // determine lba by going to fake zone offset and readding offset.
   uint64_t slba = (lba / zone_size_) * zone_cap_;
   uint64_t slba_offset = lba % zone_size_;
-  // printf("translate pba to lba %lu %lu %lu\n", lba, slba, slba_offset);
   return slba + slba_offset;
 }
 
@@ -109,6 +107,7 @@ SZDStatus SZDChannel::FlushBufferSection(uint64_t *lba, const SZDBuffer &buffer,
   void *cbuffer;
   SZDStatus s = SZDStatus::Success;
   if ((s = buffer.GetBuffer(&cbuffer)) != SZDStatus::Success) {
+    SZD_LOG_ERROR("SZD: Channel: FlushBufferSection: GetBuffer\n");
     return s;
   }
   // Diag
@@ -116,6 +115,7 @@ SZDStatus SZDChannel::FlushBufferSection(uint64_t *lba, const SZDBuffer &buffer,
   // We need two steps because it will not work with one buffer.
   if (alligned_size != size) {
     if (backed_memory_spill_ == nullptr) {
+      SZD_LOG_ERROR("SZD: Channel: FlushBufferSection: No spill buffer\n");
       return SZDStatus::IOError;
     }
     uint64_t postfix_size = lba_size_ - (alligned_size - size);
@@ -176,11 +176,13 @@ SZDStatus SZDChannel::ReadIntoBuffer(uint64_t lba, SZDBuffer *buffer,
   void *cbuffer;
   SZDStatus s = SZDStatus::Success;
   if ((s = buffer->GetBuffer(&cbuffer)) != SZDStatus::Success) {
+    SZD_LOG_ERROR("SZD: Channel: ReadIntoBuffer: GetBuffer\n");
     return s;
   }
   // We need two steps because it will not work with one buffer.
   if (alligned_size != size) {
     if (backed_memory_spill_ == nullptr) {
+      SZD_LOG_ERROR("SZD: Channel: ReadIntoBuffer: No spill buffer\n");
       return SZDStatus::IOError;
     }
     uint64_t postfix_size = lba_size_ - (alligned_size - size);
@@ -227,13 +229,13 @@ SZDStatus SZDChannel::DirectAppend(uint64_t *lba, void *buffer,
       (new_lba - slba + (alligned_size / lba_size_)) / zone_cap_;
   if (slba + zones_needed * zone_size_ > max_lba_ ||
       (alligned && size != allign_size(size))) {
-    printf("Invalid arguments for DirectAppend\n");
+    SZD_LOG_ERROR("SZD: Channel: DirectAppend: OOB\n");
     return SZDStatus::InvalidArguments;
   }
   // Create temporary DMA buffer of ZASL size
   void *dma_buffer = szd_calloc(lba_size_, 1, zasl_);
   if (dma_buffer == nullptr) {
-    printf("No DMA memory left\n");
+    SZD_LOG_ERROR("SZD: Channel: DirectAppend: No DMA buffer\n");
     return SZDStatus::IOError;
   }
   // Write in steps of ZASL
@@ -261,7 +263,7 @@ SZDStatus SZDChannel::DirectAppend(uint64_t *lba, void *buffer,
     append_operations_[(new_lba - min_lba_) / zone_size_] += 1;
 
     if (s != SZDStatus::Success) {
-      printf("DirectWrite error \n");
+      SZD_LOG_ERROR("SZD: Channel: DirectAppend: Could not write\n");
       break;
     }
     begin += stepsize;
@@ -286,13 +288,13 @@ SZDStatus SZDChannel::DirectRead(uint64_t lba, void *buffer, uint64_t size,
       (lba - slba + (alligned_size / lba_size_)) / zone_cap_;
   if (slba + zones_needed * zone_size_ > max_lba_ ||
       (alligned && size != allign_size(size))) {
-    printf("Directread invalid arguments \n");
+    SZD_LOG_ERROR("SZD: Channel: DirectRead: OOB\n");
     return SZDStatus::InvalidArguments;
   }
   // Create temporary DMA buffer to copy other DMA buffer data into.
   void *buffer_dma = szd_calloc(lba_size_, 1, mdts_);
   if (buffer_dma == nullptr) {
-    printf("No DMA memory left for reading\n");
+    SZD_LOG_ERROR("SZD: Channel: DirectRead: OOM\n");
     return SZDStatus::IOError;
   }
   // Read in steps of MDTS
@@ -319,7 +321,7 @@ SZDStatus SZDChannel::DirectRead(uint64_t lba, void *buffer, uint64_t size,
     if (s == SZDStatus::Success) {
       memcpy((char *)buffer + begin, buffer_dma, alligned_step);
     } else {
-      printf("Error in DirectRead\n");
+      SZD_LOG_ERROR("SZD: Channel: DirectRead: Could not read\n");
       break;
     }
     begin += stepsize;
@@ -349,7 +351,7 @@ SZDStatus SZDChannel::AsyncAppend(uint64_t *lba, void *buffer,
   uint64_t zones_needed =
       (new_lba - slba + (alligned_size / lba_size_)) / zone_cap_;
   if (zones_needed > 1) {
-    printf("Invalid arguments for DirectAsyncAppend\n");
+    SZD_LOG_ERROR("SZD: Channel: AsyncAppend: OOB\n");
     return SZDStatus::InvalidArguments;
   }
   // Create temporary DMA buffer and copy normal buffer to DMA.
@@ -365,7 +367,7 @@ SZDStatus SZDChannel::AsyncAppend(uint64_t *lba, void *buffer,
     memset(async_buffer_[writer], 0, async_buffer_size_[writer]);
   }
   if (async_buffer_[writer] == nullptr) {
-    printf("No DMA memory left\n");
+    SZD_LOG_ERROR("SZD: Channel: AsyncAppend: OOM\n");
     return SZDStatus::IOError;
   }
   memcpy(async_buffer_[writer], buffer, size);
@@ -451,6 +453,7 @@ SZDStatus SZDChannel::Sync() {
     }
     s = FromStatus(szd_poll_async(qpair_, completion_[i]));
     if (s != SZDStatus::Success) {
+      SZD_LOG_ERROR("SZD: Channel: Sync: Failed a poll\n");
       break;
     }
     // Remove temporary buffer.
@@ -467,7 +470,7 @@ SZDStatus SZDChannel::Sync() {
 SZDStatus SZDChannel::ResetZone(uint64_t slba) {
   slba = TranslateLbaToPba(slba);
   if (slba < min_lba_ || slba > max_lba_) {
-    printf("Reset out of range %lu  - %lu -  %lu\n", min_lba_, slba, max_lba_);
+    SZD_LOG_ERROR("SZD: Channel: ResetZone: OOB\n");
     return SZDStatus::InvalidArguments;
   }
   SZDStatus s = FromStatus(szd_reset(qpair_, slba));
@@ -482,6 +485,7 @@ SZDStatus SZDChannel::ResetAllZones() {
   if (!can_access_all_) {
     for (uint64_t slba = min_lba_; slba != max_lba_; slba += zone_size_) {
       if ((s = FromStatus(szd_reset(qpair_, slba))) != SZDStatus::Success) {
+        SZD_LOG_ERROR("SZD: Channel: ResetAllZones: OOB\n");
         return s;
       }
       zones_reset_counter_.fetch_add(1, std::memory_order_relaxed);
@@ -502,6 +506,7 @@ SZDStatus SZDChannel::ResetAllZones() {
 SZDStatus SZDChannel::ZoneHead(uint64_t slba, uint64_t *zone_head) {
   slba = TranslateLbaToPba(slba);
   if (slba < min_lba_ || slba > max_lba_) {
+    SZD_LOG_ERROR("SZD: Channel: ZoneHead: OOB\n");
     return SZDStatus::InvalidArguments;
   }
   SZDStatus s = FromStatus(szd_get_zone_head(qpair_, slba, zone_head));
@@ -512,6 +517,7 @@ SZDStatus SZDChannel::ZoneHead(uint64_t slba, uint64_t *zone_head) {
 SZDStatus SZDChannel::FinishZone(uint64_t slba) {
   slba = TranslateLbaToPba(slba);
   if (slba < min_lba_ || slba > max_lba_) {
+    SZD_LOG_ERROR("SZD: Channel: FinishZone: OOB\n");
     return SZDStatus::InvalidArguments;
   }
   SZDStatus s = FromStatus(szd_finish_zone(qpair_, slba));

--- a/szd/cpp/src/szd_channel_factory.cpp
+++ b/szd/cpp/src/szd_channel_factory.cpp
@@ -15,6 +15,7 @@ SZDChannelFactory::~SZDChannelFactory() {}
 
 SZDStatus SZDChannelFactory::register_raw_qpair(QPair **qpair) {
   if (channel_count_ >= max_channel_count_ || qpair == nullptr) {
+    SZD_LOG_ERROR("SZD: Channel factory: Too many QPairs\n");
     return SZDStatus::InvalidArguments;
   }
   SZDStatus s = FromStatus(szd_create_qpair(device_manager_, qpair));
@@ -38,12 +39,14 @@ SZDStatus SZDChannelFactory::register_channel(SZDChannel **channel,
                                               bool preserve_async_buffer,
                                               uint32_t channel_depth) {
   if (channel_count_ >= max_channel_count_) {
+    SZD_LOG_ERROR("SZD: Channel factory: Too many Channels\n");
     return SZDStatus::InvalidArguments;
   }
   SZDStatus s;
   QPair **qpair = new QPair *;
   if ((s = FromStatus(szd_create_qpair(device_manager_, qpair))) !=
       SZDStatus::Success) {
+    SZD_LOG_ERROR("SZD: Channel factory: Could not create QPair\n");
     return s;
   }
   *channel =

--- a/szd/cpp/src/szd_device.cpp
+++ b/szd/cpp/src/szd_device.cpp
@@ -34,6 +34,7 @@ SZDStatus SZDDevice::Init() {
 
 SZDStatus SZDDevice::Reinit() {
   if (initialised_device_ != true) {
+    SZD_LOG_ERROR("SZD: Device: Reinit: Not initialised\n");
     return SZDStatus::InvalidArguments;
   }
   SZDStatus s = FromStatus(szd_reinit(manager_));
@@ -45,11 +46,13 @@ SZDStatus SZDDevice::Reinit() {
 
 SZDStatus SZDDevice::Probe(std::vector<DeviceOpenInfo> &info) {
   if (!initialised_device_) {
+    SZD_LOG_ERROR("SZD: Device: Probe: Invalid args\n");
     return SZDStatus::InvalidArguments;
   }
   ProbeInformation **prober = new ProbeInformation *;
   SZDStatus s = FromStatus(szd_probe(*manager_, prober));
   if (s != SZDStatus::Success) {
+    SZD_LOG_ERROR("SZD: Device: Probe: Failed probing\n");
     return s;
   }
   for (uint8_t dev = 0; dev < (*prober)->devices; dev++) {
@@ -68,6 +71,7 @@ SZDStatus SZDDevice::Probe(std::vector<DeviceOpenInfo> &info) {
 SZDStatus SZDDevice::Open(const std::string &device_name, uint64_t min_zone,
                           uint64_t max_zone) {
   if (!initialised_device_ || device_opened_) {
+    SZD_LOG_ERROR("SZD: Device: Open: Invalid args/state\n");
     return SZDStatus::InvalidArguments;
   }
   opened_device_.assign(device_name);
@@ -85,6 +89,7 @@ SZDStatus SZDDevice::Open(const std::string &device_name) {
 
 SZDStatus SZDDevice::Close() {
   if (!initialised_device_ || !device_opened_) {
+    SZD_LOG_ERROR("SZD: Device: Close: Nothing to close\n");
     return SZDStatus::InvalidArguments;
   }
   device_opened_ = false;
@@ -93,6 +98,7 @@ SZDStatus SZDDevice::Close() {
 
 SZDStatus SZDDevice::GetInfo(DeviceInfo *info) const {
   if (!device_opened_) {
+    SZD_LOG_ERROR("SZD: Device: GetInfo: Not initialised\n");
     return SZDStatus::InvalidArguments;
   }
   *info = (*manager_)->info;
@@ -101,6 +107,7 @@ SZDStatus SZDDevice::GetInfo(DeviceInfo *info) const {
 
 SZDStatus SZDDevice::Destroy() {
   if (!initialised_device_) {
+    SZD_LOG_ERROR("SZD: Device: Destroy: Not initialised\n");
     return SZDStatus::InvalidArguments;
   }
   SZDStatus s = FromStatus(szd_destroy(*manager_));


### PR DESCRIPTION
## What is the intent of this PR?
Remove printfs from SZD, we do not want them. They pollute the code, lead to performance issues and make it hard to enable/disable debug environments. We also added some minor optimisations.
* Move all printfs to custom logger that is disabled in production
* Formalise debug print format
* Disable most NULL checks in production
* Add likely/unlikely markers (for code clarity and perf, not tested)

## Checklist
- [ :no_entry:  all tests complete. Make sure you have `-DTESTING=1` and `make test` completes.
- [:heavy_check_mark:] code is formatted. This includes ALL code. For now, this can be done with:
```bash
mkdir -p build && cd build
cmake -DTESTING=1 -DSZD_TOOLS="szdcli; reset_perf" ..
make format
```
