### PR TITLE
Update once_log API

### DIFF
--- a/cmake/FindSPDK.cmake
+++ b/cmake/FindSPDK.cmake
@@ -19,7 +19,6 @@ pkg_search_module(DPDK REQUIRED IMPORTED_TARGET spdk_env_dpdk)
 pkg_search_module(SYS REQUIRED IMPORTED_TARGET spdk_syslibs)
 
 set(SPDK_INCLUDE_DIRS "${SPDK_INCLUDE_DIRS}")
-set(SPDK_LIBRARY_DIRS "${SPDK_LIBRARY_DIRS};${DPDK_LIBRARY_DIRS};${SYS_STATIC_LIBRARY_DIRS}")
 
 # TODO: Solve this once there is one sane CMake for SPDK somewhere
 # The following is what is done in the wiki of SPDK, but does not work as of 2022-11-09.

--- a/szd/cpp/include/szd/datastructures/szd_once_log.hpp
+++ b/szd/cpp/include/szd/datastructures/szd_once_log.hpp
@@ -16,14 +16,18 @@
 #include <deque>
 #include <functional>
 #include <string>
+#include <variant>
 
 namespace SIMPLE_ZNS_DEVICE_NAMESPACE {
+
+typedef std::variant<uint32_t, SZDChannel *> queue_depth_or_external_channel;
+
 class SZDOnceLog : public SZDLog {
 public:
+  // Either specify an external channel (borrowed by once log), or a queue depth
   SZDOnceLog(SZDChannelFactory *channel_factory, const DeviceInfo &info,
              const uint64_t min_zone_nr, const uint64_t max_zone_nr,
-             const uint8_t number_of_writers,
-             SZDChannel **write_channel = nullptr);
+             const queue_depth_or_external_channel channel_definition);
   ~SZDOnceLog() override;
 
   // Direct IO
@@ -58,7 +62,7 @@ public:
   inline bool SpaceLeft(const size_t size,
                         bool alligned = true) const override {
     uint64_t alligned_size =
-        alligned ? size : write_channel_[0]->allign_size(size);
+        alligned ? size : write_channel_->allign_size(size);
     return alligned_size <= space_left_;
   }
 
@@ -67,60 +71,38 @@ public:
   inline uint8_t GetNumberOfReaders() const override { return 1; };
 
   inline uint64_t GetBytesWritten() const override {
-    uint64_t bytes_written = 0;
-    for (uint8_t i = 0; i < number_of_writers_; i++) {
-      bytes_written += write_channel_[i]->GetBytesWritten();
-    }
-    return bytes_written;
+    return write_channel_->GetBytesWritten();
   };
   inline uint64_t GetAppendOperationsCounter() const override {
-    uint64_t append_operations = 0;
-    for (uint8_t i = 0; i < number_of_writers_; i++) {
-      append_operations += write_channel_[i]->GetAppendOperationsCounter();
-    }
-    return append_operations;
+    return write_channel_->GetAppendOperationsCounter();
   };
   inline uint64_t GetBytesRead() const override {
-    return read_channel_->GetBytesRead();
+    return read_reset_channel_->GetBytesRead();
   };
   inline uint64_t GetReadOperationsCounter() const override {
-    return read_channel_->GetReadOperationsCounter();
+    return read_reset_channel_->GetReadOperationsCounter();
   };
   inline uint64_t GetZonesResetCounter() const override {
-    uint64_t reset_operations = 0;
-    reset_operations += read_channel_->GetZonesResetCounter();
-    return reset_operations;
+    return read_reset_channel_->GetZonesResetCounter();
   };
   inline std::vector<uint64_t> GetZonesReset() const override {
-    std::vector<uint64_t> resets = read_channel_->GetZonesReset();
-    return resets;
+    return read_reset_channel_->GetZonesReset();
   };
   inline std::vector<uint64_t> GetAppendOperations() const override {
-    std::vector<uint64_t> resets = write_channel_[0]->GetAppendOperations();
-    for (uint8_t i = 1; i < number_of_writers_; i++) {
-      std::vector<uint64_t> tmp = write_channel_[i]->GetAppendOperations();
-      std::transform(resets.begin(), resets.end(), tmp.begin(), tmp.begin(),
-                     std::plus<uint64_t>());
-    }
-    return resets;
+    return write_channel_->GetAppendOperations();
   };
 
 private:
   bool IsValidAddress(uint64_t lba, uint64_t lbas);
   // log
-  const uint8_t number_of_writers_;
   const uint64_t block_range_;
+  uint32_t max_write_depth_;
   uint64_t space_left_;
   uint64_t write_head_;
   uint64_t zasl_;
-  // stall writes
-  // SZDBuffer write_buffer_;
-  // references
-  // TODO: cleanup, we only use 1 channel at most, we have moved logic to queue
-  // pairs
-  SZDChannel **write_channel_;
-  uint32_t qpair_depth_;
-  SZDChannel *read_channel_;
+  // channels used
+  SZDChannel *write_channel_;
+  SZDChannel *read_reset_channel_;
   bool write_channels_owned_;
 };
 } // namespace SIMPLE_ZNS_DEVICE_NAMESPACE

--- a/szd/cpp/src/datastructures/szd_once_log.cpp
+++ b/szd/cpp/src/datastructures/szd_once_log.cpp
@@ -3,31 +3,29 @@
 #include "szd/szd_channel_factory.hpp"
 
 #include <cassert>
+#include <variant>
 
 namespace SIMPLE_ZNS_DEVICE_NAMESPACE {
 SZDOnceLog::SZDOnceLog(SZDChannelFactory *channel_factory,
                        const DeviceInfo &info, const uint64_t min_zone_nr,
                        const uint64_t max_zone_nr,
-                       const uint8_t number_of_writers,
-                       SZDChannel **write_channel)
+                       const queue_depth_or_external_channel channel_definition)
     : SZDLog(channel_factory, info, min_zone_nr, max_zone_nr),
-      number_of_writers_(number_of_writers),
       block_range_((max_zone_nr - min_zone_nr) * info.zone_cap),
       space_left_(block_range_ * info.lba_size), write_head_(0),
-      zasl_(info.zasl), write_channel_(write_channel),
-      write_channels_owned_(false) {
+      zasl_(info.zasl), write_channels_owned_(false) {
   write_head_ = min_zone_head_;
   channel_factory_->Ref();
-  if (write_channel_ == nullptr) {
-    write_channel_ = new SZD::SZDChannel *[number_of_writers_];
-    for (uint8_t i = 0; i < number_of_writers_; i++) {
-      channel_factory_->register_channel(&write_channel_[i], min_zone_nr,
-                                         max_zone_nr);
-    }
+  if (std::holds_alternative<SZDChannel *>(channel_definition)) {
+    write_channel_ = std::get<SZDChannel *>(channel_definition);
+    max_write_depth_ = write_channel_->GetQueueDepth();
+    write_channels_owned_ = false;
   } else {
+    max_write_depth_ = std::get<uint32_t>(channel_definition);
+    channel_factory_->register_channel(&write_channel_, min_zone_nr,
+                                       max_zone_nr, true, max_write_depth_);
     write_channels_owned_ = true;
   }
-  qpair_depth_ = write_channel_[0]->GetQueueDepth();
 
 #ifdef EstimatedQueue
   // Create free queue
@@ -35,21 +33,20 @@ SZDOnceLog::SZDOnceLog(SZDChannelFactory *channel_factory,
     frees.push_back(i);
   }
 #endif
-  channel_factory_->register_channel(&read_channel_, min_zone_nr, max_zone_nr);
+  channel_factory_->register_channel(&read_reset_channel_, min_zone_nr,
+                                     max_zone_nr);
 }
 
 SZDOnceLog::~SZDOnceLog() {
   Sync();
-  if (!write_channels_owned_ && write_channel_ != nullptr) {
-    for (uint8_t i = 0; i < number_of_writers_; i++) {
-      if (write_channel_[i]) {
-        channel_factory_->unregister_channel(write_channel_[i]);
-      }
+  if (write_channels_owned_) {
+    if (write_channel_ != nullptr) {
+      channel_factory_->unregister_channel(write_channel_);
     }
-    delete[] write_channel_;
   }
-  if (read_channel_ != nullptr) {
-    channel_factory_->unregister_channel(read_channel_);
+
+  if (read_reset_channel_ != nullptr) {
+    channel_factory_->unregister_channel(read_reset_channel_);
   }
   channel_factory_->Unref();
 }
@@ -65,8 +62,7 @@ SZDStatus SZDOnceLog::Append(const char *data, const size_t size,
     return SZDStatus::IOError;
   }
   uint64_t write_head_old = write_head_;
-  s = write_channel_[0]->DirectAppend(&write_head_, (void *)data, size,
-                                      alligned);
+  s = write_channel_->DirectAppend(&write_head_, (void *)data, size, alligned);
   uint64_t blocks = write_head_ - write_head_old;
   if (lbas != nullptr) {
     *lbas = blocks;
@@ -91,8 +87,8 @@ SZDStatus SZDOnceLog::Append(const SZDBuffer &buffer, size_t addr, size_t size,
     return SZDStatus::IOError;
   }
   uint64_t write_head_old = write_head_;
-  s = write_channel_[0]->FlushBufferSection(&write_head_, buffer, addr, size,
-                                            alligned);
+  s = write_channel_->FlushBufferSection(&write_head_, buffer, addr, size,
+                                         alligned);
   uint64_t blocks = write_head_ - write_head_old;
   if (lbas != nullptr) {
     *lbas = blocks;
@@ -112,7 +108,7 @@ SZDStatus SZDOnceLog::Append(const SZDBuffer &buffer, uint64_t *lbas) {
     return SZDStatus::IOError;
   }
   uint64_t write_head_old = write_head_;
-  s = write_channel_[0]->FlushBuffer(&write_head_, buffer);
+  s = write_channel_->FlushBuffer(&write_head_, buffer);
   uint64_t blocks = write_head_ - write_head_old;
   if (lbas != nullptr) {
     *lbas = blocks;
@@ -133,7 +129,7 @@ SZDStatus SZDOnceLog::AsyncAppend(const char *data, const size_t size,
   }
   uint64_t zone_end = (write_head_ / zone_cap_) * zone_cap_ + zone_cap_;
   // Check if possible to even do async
-  uint64_t alligned_size = write_channel_[0]->allign_size(size);
+  uint64_t alligned_size = write_channel_->allign_size(size);
   uint64_t blocks_needed = alligned_size / lba_size_;
   bool can_do_async = blocks_needed <= zasl_ / lba_size_ &&
                       write_head_ + blocks_needed < zone_end;
@@ -143,19 +139,19 @@ SZDStatus SZDOnceLog::AsyncAppend(const char *data, const size_t size,
   if (!can_do_async) {
     s = Sync();
     claimed_nr = 0;
-    s = write_channel_[0]->DirectAppend(&write_head_, (void *)data, size,
-                                        alligned);
+    s = write_channel_->DirectAppend(&write_head_, (void *)data, size,
+                                     alligned);
   } else {
     // Spinlock-like, but over all queues one by one each time.
     uint64_t waiting = 0;
     while (true) {
-      if (write_channel_[0]->FindFreeWriter(&claimed_nr)) {
+      if (write_channel_->FindFreeWriter(&claimed_nr)) {
         break;
       }
       waiting++;
     }
-    s = write_channel_[0]->AsyncAppend(&write_head_, (void *)data, size,
-                                       claimed_nr);
+    s = write_channel_->AsyncAppend(&write_head_, (void *)data, size,
+                                    claimed_nr);
   }
   if (lbas != nullptr) {
     *lbas = blocks_needed;
@@ -170,12 +166,10 @@ SZDStatus SZDOnceLog::Sync() {
   frees.clear();
   waits.clear();
 #endif
-  for (uint8_t i = 0; i < number_of_writers_; i++) {
-    s = write_channel_[i]->Sync();
+  s = write_channel_->Sync();
 #ifdef EstimatedQueue
-    frees.push_back(i);
+  frees.push_back(0);
 #endif
-  }
   return s;
 }
 
@@ -185,32 +179,32 @@ bool SZDOnceLog::IsValidAddress(uint64_t lba, uint64_t lbas) {
 
 SZDStatus SZDOnceLog::Read(uint64_t lba, char *data, uint64_t size,
                            bool alligned, uint8_t /*reader*/) {
-  if (szd_unlikely(
-          !IsValidAddress(lba, read_channel_->allign_size(size) / lba_size_))) {
+  if (szd_unlikely(!IsValidAddress(lba, read_reset_channel_->allign_size(size) /
+                                            lba_size_))) {
     SZD_LOG_ERROR("SZD: Once log: Read: Invalid args\n");
     return SZDStatus::InvalidArguments;
   }
-  return read_channel_->DirectRead(lba, data, size, alligned);
+  return read_reset_channel_->DirectRead(lba, data, size, alligned);
 }
 
 SZDStatus SZDOnceLog::Read(uint64_t lba, SZDBuffer *buffer, uint64_t size,
                            bool alligned, uint8_t /*reader*/) {
-  if (szd_unlikely(
-          !IsValidAddress(lba, read_channel_->allign_size(size) / lba_size_))) {
+  if (szd_unlikely(!IsValidAddress(lba, read_reset_channel_->allign_size(size) /
+                                            lba_size_))) {
     SZD_LOG_ERROR("SZD: Once log: Read: Invalid args\n");
     return SZDStatus::InvalidArguments;
   }
-  return read_channel_->ReadIntoBuffer(lba, buffer, 0, size, alligned);
+  return read_reset_channel_->ReadIntoBuffer(lba, buffer, 0, size, alligned);
 }
 
 SZDStatus SZDOnceLog::Read(uint64_t lba, SZDBuffer *buffer, size_t addr,
                            size_t size, bool alligned, uint8_t /*reader*/) {
-  if (szd_unlikely(
-          !IsValidAddress(lba, read_channel_->allign_size(size) / lba_size_))) {
+  if (szd_unlikely(!IsValidAddress(lba, read_reset_channel_->allign_size(size) /
+                                            lba_size_))) {
     SZD_LOG_ERROR("SZD: Once log: Read: Invalid args\n");
     return SZDStatus::InvalidArguments;
   }
-  return read_channel_->ReadIntoBuffer(lba, buffer, addr, size, alligned);
+  return read_reset_channel_->ReadIntoBuffer(lba, buffer, addr, size, alligned);
 }
 
 SZDStatus SZDOnceLog::ReadAll(std::string &out) {
@@ -221,7 +215,7 @@ SZDStatus SZDOnceLog::ReadAll(std::string &out) {
   }
   char *dat = new char[size_needed + 1];
   SZDStatus s =
-      read_channel_->DirectRead(GetWriteTail(), dat, size_needed, true);
+      read_reset_channel_->DirectRead(GetWriteTail(), dat, size_needed, true);
   if (szd_unlikely(s != SZDStatus::Success)) {
     SZD_LOG_ERROR("SZD: Once log: ReadAll: Failed\n");
     return s;
@@ -235,7 +229,7 @@ SZDStatus SZDOnceLog::ResetAll() {
   SZDStatus s;
   for (uint64_t slba = min_zone_head_;
        slba < max_zone_head_ && slba < write_head_; slba += zone_cap_) {
-    s = read_channel_->ResetZone(slba);
+    s = read_reset_channel_->ResetZone(slba);
     if (szd_unlikely(s != SZDStatus::Success)) {
       SZD_LOG_ERROR("SZD: Once log: ResetZone\n");
       return s;
@@ -247,7 +241,9 @@ SZDStatus SZDOnceLog::ResetAll() {
   return s;
 }
 
-SZDStatus SZDOnceLog::ResetAllForce() { return read_channel_->ResetAllZones(); }
+SZDStatus SZDOnceLog::ResetAllForce() {
+  return read_reset_channel_->ResetAllZones();
+}
 
 SZDStatus SZDOnceLog::RecoverPointers() {
   SZDStatus s;
@@ -255,7 +251,7 @@ SZDStatus SZDOnceLog::RecoverPointers() {
   uint64_t zone_head = min_zone_head_;
   for (uint64_t slba = min_zone_head_; slba < max_zone_head_;
        slba += zone_cap_) {
-    s = read_channel_->ZoneHead(slba, &zone_head);
+    s = read_reset_channel_->ZoneHead(slba, &zone_head);
     if (szd_unlikely(s != SZDStatus::Success)) {
       SZD_LOG_ERROR("SZD: Once log: Recover pointers\n");
       return s;
@@ -279,7 +275,7 @@ SZDStatus SZDOnceLog::MarkInactive() {
   if ((write_head_ / zone_cap_) * zone_cap_ != write_head_) {
     uint64_t wasted_space =
         (write_head_ / zone_cap_) * zone_cap_ + zone_cap_ - write_head_;
-    s = read_channel_->FinishZone((write_head_ / zone_cap_) * zone_cap_);
+    s = read_reset_channel_->FinishZone((write_head_ / zone_cap_) * zone_cap_);
     space_left_ -= wasted_space * lba_size_;
     write_head_ += wasted_space;
   }

--- a/tools/reset_perf/reset_perf.cc
+++ b/tools/reset_perf/reset_perf.cc
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
   // Logs make writes easier
   if (fill) {
     SZD::SZDOnceLog *log = new SZD::SZDOnceLog(
-        &factory, info, 0, info.max_lba / info.zone_size, 1, &channel);
+        &factory, info, 0, info.max_lba / info.zone_size, channel);
     // Create the write buffer
     size_t range_to_write = info.zasl;
     char fill_buff[range_to_write + 1];


### PR DESCRIPTION
## What is the intent of this PR?
The PR alters the once_log API. In practice this means:
* Setting  number of writers for once_logs is obsoleted and removed.
* Instead a user should either use one external channel or create the channel within the log and specify the max queue depth.
* Read channel is renamed to read_reset_channel as it is responsible for both actions.

## Checklist
- [ :heavy_check_mark:] all tests complete. Make sure you have `-DTESTING=1` and `make test` completes.
- [:heavy_check_mark:] code is formatted. This includes ALL code. For now, this can be done with:
```bash
mkdir -p build && cd build
cmake -DTESTING=1 -DSZD_TOOLS="szdcli; reset_perf" ..
make format
```
