### PR TITLE
POC of USDT probes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,12 @@ function(SETUP_SZD_PROJECT_STRUCTURE project_name)
     )
 endfunction()
 
+# USDT
+option(USE_USDT "Turn on USDT probes (DTRACE)" OFF)
+if (USE_USDT)
+    add_definitions(-DSZD_USDT)
+endif()
+
 # Libraries...
 add_library(szd STATIC
     "${szd_core_include_files}"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ SZD is the main interface between SPDK and this project. It should be minimalist
 ## SZD_extended
 SZD_extended wraps the interface of Core into a more C++-like interface. It also comes with some extra utilities on top of the interface. Such as some common data structures such as logs. Header files should be created with `.hpp` and stored in `./szd/cpp/include/szd`. Source files should be created with `.cpp` in `./szd/cpp/src`. Tests are created by using [Google Test](https://github.com/google/googletest). 
 
+## Tracing
+It is possible to trace a few calls in SZD. We might add more later, the current ones are mainly for debugging/insight. These are static trace USDT tracepoints. They can be easily found with `grep -r SZD_DTRACE_PROBE ./szd/*`.
+They are disabled by default, but can be enabled with `-DUSE_USDT=1`.
+Then it is as simple as using a tool such as BPFtrace and using scripts such as (with _EXE_ the path to the executable):
+```shell
+bpftrace -e 'usdt:_EXE_:szd_init { printf("Initialised device...\n"); @["Init"] = count(); }'
+```
+
 ## Formatting
 If submitting code, please format the code. This prevents spurious commit changes. We use `clang-format` with the config in `.clang-format`, based on `LLVM`. It is possible to automatically format with make or ninja (depending on what build tool is used). This requires clang-format to be either set in `/home/$USER/bin/clang-format` or requires setting the environmental variable `CLANG_FORMAT_PATH` directly (e.g. `export CLANG_FORMAT_PATH=...`). Then simply run:
 ```bash

--- a/szd/core/include/szd/szd.h
+++ b/szd/core/include/szd/szd.h
@@ -43,6 +43,10 @@
 
 #include <pthread.h>
 
+#ifdef SZD_USDT
+#include <sys/sdt.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #include <cstdint>
@@ -361,6 +365,22 @@ long int szd_spdk_strtol(const char *nptr, int base);
 // Taken directly (renamed) from spdk/likely (no leakage)
 #define szd_unlikely(cond) __builtin_expect((cond), 0)
 #define szd_likely(cond) __builtin_expect(!!(cond), 1)
+
+#ifdef SZD_USDT
+#define SZD_DTRACE_PROBE(name) DTRACE_PROBE(szd, name)
+#define SZD_DTRACE_PROBE1(name, a1) DTRACE_PROBE1(szd, name, a1)
+#define SZD_DTRACE_PROBE2(name, a1, a2) DTRACE_PROBE2(szd, name, a1, a2)
+#else
+#define SZD_DTRACE_PROBE(...)                                                  \
+  do {                                                                         \
+  } while (0)
+#define SZD_DTRACE_PROBE1(...)                                                 \
+  do {                                                                         \
+  } while (0)
+#define SZD_DTRACE_PROBE2(...)                                                 \
+  do {                                                                         \
+  } while (0)
+#endif
 
 void __szd_error_log(const char *file, const int line, const char *func,
                      const char *format, ...);

--- a/szd/core/src/szd.c
+++ b/szd/core/src/szd.c
@@ -118,6 +118,7 @@ int szd_init(DeviceManager **manager, DeviceOptions *options) {
   (*manager)->ctrlr = NULL;
   (*manager)->ns = NULL;
   (*manager)->private_ = NULL;
+  SZD_DTRACE_PROBE(szd_init);
   return SZD_SC_SUCCESS;
 }
 
@@ -284,6 +285,7 @@ int szd_open(DeviceManager *manager, const char *traddr,
   DeviceManagerInternal *private_ = (DeviceManagerInternal *)manager->private_;
   manager->info.min_lba = private_->zone_min_ * manager->info.zone_size;
   manager->info.max_lba = private_->zone_max_ * manager->info.zone_size;
+  SZD_DTRACE_PROBE(szd_open);
   return rc;
 }
 
@@ -305,6 +307,7 @@ int szd_close(DeviceManager *manager) {
   if (manager->g_trid != NULL) {
     memset(manager->g_trid, 0, sizeof(*(manager->g_trid)));
   }
+  SZD_DTRACE_PROBE(szd_closed);
   return rc != 0 ? SZD_SC_SPDK_ERROR_CLOSE : SZD_SC_SUCCESS;
 }
 
@@ -320,6 +323,7 @@ int szd_destroy(DeviceManager *manager) {
   }
   free(manager);
   spdk_env_fini();
+  SZD_DTRACE_PROBE(szd_destroy);
   return rc;
 }
 
@@ -437,6 +441,7 @@ int szd_create_qpair(DeviceManager *man, QPair **qpair) {
   (*qpair)->qpair = spdk_nvme_ctrlr_alloc_io_qpair(man->ctrlr, NULL, 0);
   (*qpair)->man = man;
   RETURN_ERR_ON_NULL((*qpair)->qpair);
+  SZD_DTRACE_PROBE(szd_create_qpair);
   return SZD_SC_SUCCESS;
 }
 
@@ -446,6 +451,7 @@ int szd_destroy_qpair(QPair *qpair) {
   spdk_nvme_ctrlr_free_io_qpair(qpair->qpair);
   qpair->man = NULL;
   free(qpair);
+  SZD_DTRACE_PROBE(szd_destroy_qpair);
   return SZD_SC_SUCCESS;
 }
 

--- a/szd/cpp/include/szd/datastructures/szd_circular_log.hpp
+++ b/szd/cpp/include/szd/datastructures/szd_circular_log.hpp
@@ -54,8 +54,8 @@ public:
     return alligned_size <= SpaceAvailable();
   }
 
-  inline uint64_t GetWriteHead() const override { return write_head_; }
-  inline uint64_t GetWriteTail() const override { return write_tail_; }
+  inline uint64_t GetWriteHead() const override { return write_head_.load(std::memory_order_acquire); }
+  inline uint64_t GetWriteTail() const override { return write_tail_.load(std::memory_order_acquire); }
   inline uint8_t GetNumberOfReaders() const override {
     return number_of_readers_;
   };

--- a/szd/cpp/include/szd/datastructures/szd_circular_log.hpp
+++ b/szd/cpp/include/szd/datastructures/szd_circular_log.hpp
@@ -54,8 +54,12 @@ public:
     return alligned_size <= SpaceAvailable();
   }
 
-  inline uint64_t GetWriteHead() const override { return write_head_.load(std::memory_order_acquire); }
-  inline uint64_t GetWriteTail() const override { return write_tail_.load(std::memory_order_acquire); }
+  inline uint64_t GetWriteHead() const override {
+    return write_head_.load(std::memory_order_acquire);
+  }
+  inline uint64_t GetWriteTail() const override {
+    return write_tail_.load(std::memory_order_acquire);
+  }
   inline uint8_t GetNumberOfReaders() const override {
     return number_of_readers_;
   };


### PR DESCRIPTION
## What is the intent of this PR?
Showcase that USDT can be used from within user-space and it works within SZD.
Later on we can add more useful static trace points.
We also sneak in one fix for atomics in the circular log.

## Checklist
- [ :heavy_check_mark: ] all tests complete. Make sure you have `-DTESTING=1` and `make test` completes.
- [ :heavy_check_mark: ] code is formatted. This includes ALL code. For now, this can be done with:
```bash
mkdir -p build && cd build
cmake -DTESTING=1 -DSZD_TOOLS="szdcli; reset_perf" ..
make format
```
