### PR TITLE
Add szd_get_zone_heads

### DIFF
--- a/szd/core/include/szd/szd.h
+++ b/szd/core/include/szd/szd.h
@@ -336,6 +336,20 @@ int szd_get_zone_head(QPair *qpair, uint64_t slba, uint64_t *write_head);
  * @param qpair channel to use for I/O
  * @param slba starting logical block address of zone to get the write head
  * from.
+ * @param eslba end logical block address of zone to get the write head
+ * from. Must still be the beginning of the zone can be equal to slba.
+ * @param write_head pointer to store the write heads in. Must be allocated
+ * before and must have at least (eslba - slba + 1) / zone_size.
+ */
+int szd_get_zone_heads(QPair *qpair, uint64_t slba, uint64_t eslba,
+                       uint64_t *write_head);
+
+/**
+ * @brief Gets the write head of a zone synchronously as a logical block
+ * address (lba).
+ * @param qpair channel to use for I/O
+ * @param slba starting logical block address of zone to get the write head
+ * from.
  * @param zone_cap capacity of a zone.
  */
 int szd_get_zone_cap(QPair *qpair, uint64_t slba, uint64_t *zone_cap);

--- a/szd/cpp/include/szd/szd_channel.hpp
+++ b/szd/cpp/include/szd/szd_channel.hpp
@@ -84,6 +84,8 @@ public:
   SZDStatus ResetZone(uint64_t slba);
   SZDStatus ResetAllZones();
   SZDStatus ZoneHead(uint64_t slba, uint64_t *zone_head);
+  SZDStatus ZoneHeads(uint64_t slba, uint64_t eslba,
+                      std::vector<uint64_t> *zone_heads);
   SZDStatus FinishZone(uint64_t slba);
 
   // Used to aid with the fact that zonecap != zonesize

--- a/szd/cpp/src/datastructures/szd_circular_log.cpp
+++ b/szd/cpp/src/datastructures/szd_circular_log.cpp
@@ -400,13 +400,13 @@ SZDStatus SZDCircularLog::RecoverPointers() {
 
   // Retrieve zone heads from the device
   std::vector<uint64_t> zone_heads;
-  s = reset_channel_->ZoneHeads(min_zone_head_, max_zone_head_, &zone_heads);
+  s = reset_channel_->ZoneHeads(min_zone_head_, max_zone_head_ - zone_cap_, &zone_heads);
   if (szd_unlikely(s != SZDStatus::Success)) {
     SZD_LOG_ERROR("SZD: Once log: Recover pointers\n");
     return s;
   }
   if (zone_heads.size() !=
-      ((max_zone_head_ - min_zone_head_) / zone_cap_) + 1) {
+      ((max_zone_head_ - min_zone_head_ - zone_cap_) / zone_cap_) + 1) {
     SZD_LOG_ERROR("SZD: Once log: ZoneHeads did not return all heads\n");
     return SZDStatus::Unknown;
   }

--- a/szd/cpp/src/datastructures/szd_once_log.cpp
+++ b/szd/cpp/src/datastructures/szd_once_log.cpp
@@ -258,14 +258,14 @@ SZDStatus SZDOnceLog::RecoverPointers() {
 
   // Retrieve zone heads from the device
   std::vector<uint64_t> zone_heads;
-  s = read_reset_channel_->ZoneHeads(min_zone_head_, max_zone_head_,
+  s = read_reset_channel_->ZoneHeads(min_zone_head_, max_zone_head_ - zone_cap_,
                                      &zone_heads);
   if (szd_unlikely(s != SZDStatus::Success)) {
     SZD_LOG_ERROR("SZD: Once log: Recover pointers\n");
     return s;
   }
   if (zone_heads.size() !=
-      ((max_zone_head_ - min_zone_head_) / zone_cap_) + 1) {
+      ((max_zone_head_ - min_zone_head_ - zone_cap_) / zone_cap_) + 1) {
     SZD_LOG_ERROR("SZD: Once log: ZoneHeads did not return all heads\n");
     return SZDStatus::Unknown;
   }

--- a/szd/cpp/src/szd_channel.cpp
+++ b/szd/cpp/src/szd_channel.cpp
@@ -622,7 +622,7 @@ SZDStatus SZDChannel::ZoneHeads(uint64_t slba, uint64_t eslba,
                                 std::vector<uint64_t> *zone_heads) {
   slba = TranslateLbaToPba(slba);
   eslba = TranslateLbaToPba(eslba);
-  if (szd_unlikely(slba < min_lba_ || slba > max_lba_ || eslba > max_lba_ ||
+  if (szd_unlikely(slba < min_lba_ || slba >= max_lba_ || eslba >= max_lba_ ||
                    eslba < slba)) {
     SZD_LOG_ERROR("SZD: Channel: ZoneHeads: OOB\n");
     return SZDStatus::InvalidArguments;
@@ -635,6 +635,8 @@ SZDStatus SZDChannel::ZoneHeads(uint64_t slba, uint64_t eslba,
     for (uint64_t i = 0; i < head_size; i++) {
       zone_heads->push_back(TranslatePbaToLba(zone_heads_c[i]));
     }
+  } else {
+    SZD_LOG_ERROR("SZD: Channel: ZoneHeads: error in retrieving\n");
   }
   delete[] zone_heads_c;
   return s;


### PR DESCRIPTION
## What is the intent of this PR?
The function szd_get_zone_head is expensive as it reads all write pointers from disk even when we only need one zone_head. This also involves allocating a large amount of memory. SPDK implements it this way and this is not something we can solve (for now). 

To make matters worse, when we need to get many zone_heads, we repeat this process. This can take minutes. However, this problem we CAN solve. We can do one request to disk and then simply iterate over the cached write pointers once. This is done with the new function `szd_get_zone_heads`. This function is used wherever possible.

This leads to the following changes:
* New szd_get_zone_heads function in core
* Channels, once_logs and circular logs make use of the new function
* Solve an erroneous cast in szd_get_zone_head

## Checklist
- [ :heavy_check_mark: ] all tests complete. Make sure you have `-DTESTING=1` and `make test` completes.
- [ :heavy_check_mark:  ] code is formatted. This includes ALL code. For now, this can be done with:
```bash
mkdir -p build && cd build
cmake -DTESTING=1 -DSZD_TOOLS="szdcli; reset_perf" ..
make format
```
